### PR TITLE
Fix OPENJDK-1433, missing FilePermission when reading /etc/pki/java/cacerts with a SM

### DIFF
--- a/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -77,7 +77,7 @@ final class TrustStoreManager {
                 GetPropertyAction.privilegedGetProperty("java.home") +
                 fileSep + "lib" + fileSep + "security";
         private static final String defaultStore =
-            KeyStoreUtil.getCacertsKeyStoreFile().getPath();
+            KeyStoreUtil.getCacertsKeyStorePath();
         private static final String jsseDefaultStore =
                 defaultStorePath + fileSep + "jssecacerts";
 
@@ -151,22 +151,21 @@ final class TrustStoreManager {
                         String[] fileNames =
                                 new String[] {storePropName, defaultStore};
                         for (String fileName : fileNames) {
-                            if (fileName != null && !"".equals(fileName)) {
-                                File f = new File(fileName);
-                                if (f.isFile() && f.canRead()) {
-                                    temporaryName = fileName;;
-                                    temporaryFile = f;
-                                    temporaryTime = f.lastModified();
+                            File f = new File(fileName);
+                            if (f.isFile() && f.canRead()) {
+                                temporaryName = fileName;;
+                                temporaryFile = f;
+                                temporaryTime = f.lastModified();
 
-                                    break;
-                                }
-                                // Not break, the file is inaccessible.
-                                if (SSLLogger.isOn &&
+                                break;
+                            }
+
+                            // Not break, the file is inaccessible.
+                            if (SSLLogger.isOn &&
                                     SSLLogger.isOn("trustmanager")) {
-                                    SSLLogger.fine(
-                                            "Inaccessible trust store: " +
-                                            fileName);
-                                }
+                                SSLLogger.fine(
+                                        "Inaccessible trust store: " +
+                                        fileName);
                             }
                         }
                     } else {

--- a/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -77,7 +77,8 @@ final class TrustStoreManager {
                 GetPropertyAction.privilegedGetProperty("java.home") +
                 fileSep + "lib" + fileSep + "security";
         private static final String defaultStore =
-            KeyStoreUtil.getCacertsKeyStorePath();
+                AccessController.doPrivileged((PrivilegedAction<String>) () ->
+                        KeyStoreUtil.getCacertsKeyStorePath());
         private static final String jsseDefaultStore =
                 defaultStorePath + fileSep + "jssecacerts";
 

--- a/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java
+++ b/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java
@@ -33,16 +33,15 @@ import java.io.InputStreamReader;
 
 import java.net.URL;
 
-import java.security.AccessController;
 import java.security.KeyStore;
-import java.security.PrivilegedAction;
-import java.security.Security;
 
 import java.security.cert.X509Certificate;
 import java.text.Collator;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
+
+import sun.security.util.SecurityProperties;
 
 /**
  * <p> This class provides several utilities to <code>KeyStore</code>.
@@ -57,32 +56,7 @@ public class KeyStoreUtil {
 
     private static final String JKS = "jks";
 
-    private static final String PROP_NAME = "security.systemCACerts";
-
-    /**
-     * Returns the value of the security property propName, which can be overridden
-     * by a system property of the same name
-     *
-     * @param  propName the name of the system or security property
-     * @return the value of the system or security property
-     */
-    @SuppressWarnings("removal")
-    public static String privilegedGetOverridable(String propName) {
-        if (System.getSecurityManager() == null) {
-            return getOverridableProperty(propName);
-        } else {
-            return AccessController.doPrivileged((PrivilegedAction<String>) () -> getOverridableProperty(propName));
-        }
-    }
-
-    private static String getOverridableProperty(String propName) {
-        String val = System.getProperty(propName);
-        if (val == null) {
-            return Security.getProperty(propName);
-        } else {
-            return val;
-        }
-    }
+    private static final String SYSTEM_CA_CERTS_PROP = "security.systemCACerts";
 
     /**
      * Returns true if the certificate is self-signed, false otherwise.
@@ -133,8 +107,9 @@ public class KeyStoreUtil {
     {
         String sep = File.separator;
         File file = null;
-        /* Check system cacerts DB first, preferring system property over security property */
-        String systemDB = privilegedGetOverridable(PROP_NAME);
+        // Check system DB first, preferring system property over security one
+        String systemDB = SecurityProperties
+                .privilegedGetOverridable(SYSTEM_CA_CERTS_PROP);
         if (systemDB != null && !"".equals(systemDB)) {
             file = new File(systemDB);
         }

--- a/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java
+++ b/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java
@@ -103,25 +103,18 @@ public class KeyStoreUtil {
     /**
      * Returns the path to the cacerts DB
      */
-    public static File getCacertsKeyStoreFile()
+    public static String getCacertsKeyStorePath()
     {
-        String sep = File.separator;
-        File file = null;
         // Check system DB first, preferring system property over security one
         String systemDB = SecurityProperties
                 .privilegedGetOverridable(SYSTEM_CA_CERTS_PROP);
-        if (systemDB != null && !"".equals(systemDB)) {
-            file = new File(systemDB);
+        if (systemDB != null && !"".equals(systemDB) &&
+                (new File(systemDB)).isFile()) {
+            return systemDB;
         }
-        if (file == null || !file.exists()) {
-            file = new File(System.getProperty("java.home") + sep
-                            + "lib" + sep + "security" + sep
-                            + "cacerts");
-        }
-        if (file.exists()) {
-            return file;
-        }
-        return null;
+        String sep = File.separator;
+        return System.getProperty("java.home") + sep
+                + "lib" + sep + "security" + sep + "cacerts";
     }
 
     /**
@@ -130,9 +123,11 @@ public class KeyStoreUtil {
     public static KeyStore getCacertsKeyStore()
         throws Exception
     {
+        File file = new File(getCacertsKeyStorePath());
+        if (!file.exists()) {
+            return null;
+        }
         KeyStore caks = null;
-        File file = getCacertsKeyStoreFile();
-        if (file == null) { return null; }
         try (FileInputStream fis = new FileInputStream(file)) {
             caks = KeyStore.getInstance(JKS);
             caks.load(fis, null);

--- a/jdk/src/share/lib/security/java.security-aix
+++ b/jdk/src/share/lib/security/java.security-aix
@@ -296,8 +296,7 @@ security.useSystemPropertiesFile=false
 
 #
 # Specifies the system certificate store
-# This property may be disabled using
-# -Djava.security.disableSystemCACerts=true
+# This property may be disabled using an empty value
 #
 security.systemCACerts=${java.home}/lib/security/cacerts
 

--- a/jdk/src/share/lib/security/java.security-linux
+++ b/jdk/src/share/lib/security/java.security-linux
@@ -309,8 +309,7 @@ security.useSystemPropertiesFile=false
 
 #
 # Specifies the system certificate store
-# This property may be disabled using
-# -Djava.security.disableSystemCACerts=true
+# This property may be disabled using an empty value
 #
 security.systemCACerts=${java.home}/lib/security/cacerts
 

--- a/jdk/src/share/lib/security/java.security-macosx
+++ b/jdk/src/share/lib/security/java.security-macosx
@@ -299,8 +299,7 @@ security.useSystemPropertiesFile=false
 
 #
 # Specifies the system certificate store
-# This property may be disabled using
-# -Djava.security.disableSystemCACerts=true
+# This property may be disabled using an empty value
 #
 security.systemCACerts=${java.home}/lib/security/cacerts
 

--- a/jdk/src/share/lib/security/java.security-solaris
+++ b/jdk/src/share/lib/security/java.security-solaris
@@ -297,8 +297,7 @@ security.useSystemPropertiesFile=false
 
 #
 # Specifies the system certificate store
-# This property may be disabled using
-# -Djava.security.disableSystemCACerts=true
+# This property may be disabled using an empty value
 #
 security.systemCACerts=${java.home}/lib/security/cacerts
 

--- a/jdk/src/share/lib/security/java.security-windows
+++ b/jdk/src/share/lib/security/java.security-windows
@@ -299,8 +299,7 @@ security.useSystemPropertiesFile=false
 
 #
 # Specifies the system certificate store
-# This property may be disabled using
-# -Djava.security.disableSystemCACerts=true
+# This property may be disabled using an empty value
 #
 security.systemCACerts=${java.home}/lib/security/cacerts
 


### PR DESCRIPTION
# Fix [OPENJDK-1433](https://issues.redhat.com/browse/OPENJDK-1433): solr broken due to access denied ("java.io.FilePermission" "/etc/pki/java/cacerts" "read")

This pull request fixes the issue reported in [OPENJDK-1433](https://issues.redhat.com/browse/OPENJDK-1433), and makes some code cleanup (more details about this in the commit messages).

## Reproducer

```java
cat > R.java <<'EOF' && javac R.java && java -Djava.security.manager -cp . R; rm R.*

import javax.net.ssl.SSLContext;

public final class R {
    public static void main(String[] args) throws Throwable {
        SSLContext.getDefault();
        System.out.println("TEST PASS - OK");
    }
}
EOF
```

## Notes

Apart from reviewing the changes against the `cacerts` branch (default PR view), I also recommend giving a look to the [new diff against upstream code](https://github.com/rh-openjdk/jdk8u/compare/jdk8u332-ga...b8d1919c9268e31355dda0a5669e9c2724a0f814#files_bucket), only for `TrustStoreManager.java` and `KeyStoreUtil.java`.

In `git`:

```bash
git diff jdk8u332-ga b8d1919 -- *TrustStoreManager.java *KeyStoreUtil.java
```

```diff
diff --git a/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java b/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java
index e7b4763db5..0005e56f52 100644
--- a/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java
+++ b/jdk/src/share/classes/sun/security/ssl/TrustStoreManager.java
@@ -31,6 +31,7 @@ import java.security.*;
 import java.security.cert.*;
 import java.util.*;
 import sun.security.action.*;
+import sun.security.tools.KeyStoreUtil;
 import sun.security.validator.TrustStoreUtil;
 
 /**
@@ -68,7 +69,7 @@ final class TrustStoreManager {
      * The preference of the default trusted KeyStore is:
      *    javax.net.ssl.trustStore
      *    jssecacerts
-     *    cacerts
+     *    cacerts (system and local)
      */
     private static final class TrustStoreDescriptor {
         private static final String fileSep = File.separator;
@@ -76,7 +77,8 @@ final class TrustStoreManager {
                 GetPropertyAction.privilegedGetProperty("java.home") +
                 fileSep + "lib" + fileSep + "security";
         private static final String defaultStore =
-                defaultStorePath + fileSep + "cacerts";
+                AccessController.doPrivileged((PrivilegedAction<String>) () ->
+                        KeyStoreUtil.getCacertsKeyStorePath());
         private static final String jsseDefaultStore =
                 defaultStorePath + fileSep + "jssecacerts";
 
@@ -139,6 +141,10 @@ final class TrustStoreManager {
                     String storePropPassword = System.getProperty(
                             "javax.net.ssl.trustStorePassword", "");
 
+                    if (SSLLogger.isOn && SSLLogger.isOn("trustmanager")) {
+                        SSLLogger.fine("Default store: " + defaultStore);
+                    }
+
                     String temporaryName = "";
                     File temporaryFile = null;
                     long temporaryTime = 0L;
@@ -160,7 +166,7 @@ final class TrustStoreManager {
                                     SSLLogger.isOn("trustmanager")) {
                                 SSLLogger.fine(
                                         "Inaccessible trust store: " +
-                                        storePropName);
+                                        fileName);
                             }
                         }
                     } else {
diff --git a/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java b/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java
index fcc77786da..3a4388964c 100644
--- a/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java
+++ b/jdk/src/share/classes/sun/security/tools/KeyStoreUtil.java
@@ -41,6 +41,8 @@ import java.text.Collator;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import sun.security.util.SecurityProperties;
+
 /**
  * <p> This class provides several utilities to <code>KeyStore</code>.
  *
@@ -54,6 +56,8 @@ public class KeyStoreUtil {
 
     private static final String JKS = "jks";
 
+    private static final String SYSTEM_CA_CERTS_PROP = "security.systemCACerts";
+
     /**
      * Returns true if the certificate is self-signed, false otherwise.
      */
@@ -96,16 +100,30 @@ public class KeyStoreUtil {
         }
     }
 
+    /**
+     * Returns the path to the cacerts DB
+     */
+    public static String getCacertsKeyStorePath()
+    {
+        // Check system DB first, preferring system property over security one
+        String systemDB = SecurityProperties
+                .privilegedGetOverridable(SYSTEM_CA_CERTS_PROP);
+        if (systemDB != null && !"".equals(systemDB) &&
+                (new File(systemDB)).isFile()) {
+            return systemDB;
+        }
+        String sep = File.separator;
+        return System.getProperty("java.home") + sep
+                + "lib" + sep + "security" + sep + "cacerts";
+    }
+
     /**
      * Returns the keystore with the configured CA certificates.
      */
     public static KeyStore getCacertsKeyStore()
         throws Exception
     {
-        String sep = File.separator;
-        File file = new File(System.getProperty("java.home") + sep
-                             + "lib" + sep + "security" + sep
-                             + "cacerts");
+        File file = new File(getCacertsKeyStorePath());
         if (!file.exists()) {
             return null;
         }

```